### PR TITLE
Implementación básica de PWA de registro de jornadas

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ Este proyecto es una aplicación web progresiva (PWA) diseñada para digitalizar
 Repositorio iniciado el 27/07/2025. Preparado para recibir los archivos generados automáticamente por el Agente GPT.
 
 ---
+
+## Cómo ejecutar
+
+1. Instalar dependencias:
+   ```bash
+   pip install flask mysql-connector-python fpdf2
+   ```
+2. Lanzar el servidor:
+   ```bash
+   python3 app/app.py
+   ```
+3. Acceder a `http://localhost:5000` desde el navegador para usar la aplicación.
+
+La base de datos debe existir con las tablas definidas en `init.sql`. Importa el archivo en tu servidor MySQL antes de iniciar.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,136 @@
+import os
+from datetime import datetime
+from flask import Flask, render_template, request, redirect, url_for, send_file, jsonify
+import mysql.connector
+from fpdf import FPDF
+import csv
+from io import BytesIO, StringIO
+
+app = Flask(__name__)
+
+DB_CONFIG = {
+    'host': 'srv1789.hstgr.io',
+    'user': 'u643065128_ontime',
+    'password': 'Time1On2',
+    'database': 'u643065128_ontime'
+}
+
+
+def get_db_connection():
+    return mysql.connector.connect(**DB_CONFIG)
+
+@app.route('/')
+def index():
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT matricula, kms_fin FROM jornadas ORDER BY id DESC LIMIT 1")
+    last = cur.fetchone()
+    conn.close()
+    return render_template('index.html', last=last)
+
+@app.route('/guardar', methods=['POST'])
+def guardar():
+    data = request.form
+    conn = get_db_connection()
+    cur = conn.cursor()
+    sql = (
+        "INSERT INTO jornadas (fecha, hora_inicio, hora_fin, matricula, remolque, kms_inicio, kms_fin, observaciones)"
+        " VALUES (%s,%s,%s,%s,%s,%s,%s,%s)"
+    )
+    cur.execute(sql, (
+        data['fecha'], data['hora_inicio'], data['hora_fin'], data['matricula'],
+        data.get('remolque'), data['kms_inicio'], data['kms_fin'], data.get('observaciones')
+    ))
+    jornada_id = cur.lastrowid
+    trayectos = []
+    ts = data.getlist('t_hora_salida')
+    for i in range(len(ts)):
+        trayectos.append((
+            jornada_id,
+            ts[i],
+            data.getlist('t_origen')[i],
+            data.getlist('t_hora_llegada')[i],
+            data.getlist('t_destino')[i]
+        ))
+    cur.executemany(
+        "INSERT INTO trayectos (jornada_id, hora_salida, origen, hora_llegada, destino) VALUES (%s,%s,%s,%s,%s)",
+        trayectos
+    )
+    conn.commit()
+    conn.close()
+    return redirect(url_for('index'))
+
+@app.route('/jornadas')
+def jornadas():
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT * FROM jornadas ORDER BY fecha DESC, hora_inicio DESC")
+    jorn = cur.fetchall()
+    conn.close()
+    return render_template('jornadas.html', jornadas=jorn)
+
+@app.route('/jornadas/<int:id>/eliminar', methods=['POST'])
+def eliminar_jornada(id):
+    conn = get_db_connection()
+    cur = conn.cursor()
+    cur.execute("DELETE FROM jornadas WHERE id=%s", (id,))
+    conn.commit()
+    conn.close()
+    return redirect(url_for('jornadas'))
+
+@app.route('/reporte')
+def reporte():
+    inicio = request.args.get('inicio')
+    fin = request.args.get('fin')
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT * FROM jornadas WHERE fecha BETWEEN %s AND %s ORDER BY fecha", (inicio, fin))
+    datos = cur.fetchall()
+    cur.execute("SELECT SUM(horas_turno) as total FROM jornadas WHERE fecha BETWEEN %s AND %s", (inicio, fin))
+    total_horas = cur.fetchone()['total'] or 0
+    conn.close()
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font('Arial', 'B', 14)
+    pdf.cell(0, 10, f'Informe {inicio} a {fin}', 0, 1, 'C')
+    pdf.set_font('Arial', size=10)
+    for j in datos:
+        pdf.cell(0, 8, f"{j['fecha']} {j['hora_inicio']}-{j['hora_fin']} Matricula: {j['matricula']} Kms: {j['kms_inicio']}-{j['kms_fin']}", 0, 1)
+    pdf.ln(4)
+    pdf.cell(0, 8, f'Horas totales: {total_horas}', 0, 1)
+    output = BytesIO()
+    pdf.output(output)
+    output.seek(0)
+    return send_file(output, download_name='reporte.pdf', as_attachment=True)
+
+@app.route('/csv')
+def export_csv():
+    inicio = request.args.get('inicio')
+    fin = request.args.get('fin')
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT * FROM jornadas WHERE fecha BETWEEN %s AND %s ORDER BY fecha", (inicio, fin))
+    datos = cur.fetchall()
+    conn.close()
+    si = StringIO()
+    if datos:
+        writer = csv.DictWriter(si, fieldnames=datos[0].keys())
+        writer.writeheader()
+        writer.writerows(datos)
+    output = BytesIO()
+    output.write(si.getvalue().encode('utf-8'))
+    output.seek(0)
+    return send_file(output, download_name='reporte.csv', as_attachment=True)
+
+@app.route('/api/ultimas_jornadas')
+def ultimas_jornadas():
+    conn = get_db_connection()
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT * FROM jornadas ORDER BY fecha DESC, hora_inicio DESC LIMIT 7")
+    datos = cur.fetchall()
+    conn.close()
+    return jsonify(datos)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/assistant/system.txt
+++ b/app/assistant/system.txt
@@ -1,0 +1,1 @@
+Eres un asistente de voz para Antonio Becerra Ortega. Ayudas a registrar y consultar sus jornadas de conducción. Responde siempre en español de España.

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,0 +1,50 @@
+function addTrayecto() {
+    const div = document.createElement('div');
+    div.className = 'trayecto';
+    div.innerHTML = `
+        <label>Hora salida</label><input type="time" name="t_hora_salida" required>
+        <label>Origen</label><input type="text" name="t_origen" required>
+        <label>Hora llegada</label><input type="time" name="t_hora_llegada" required>
+        <label>Destino</label><input type="text" name="t_destino" required>
+        <button type="button" onclick="this.parentNode.remove()">Eliminar</button>
+        <hr>`;
+    document.getElementById('trayectos').appendChild(div);
+}
+addTrayecto();
+
+// Modal configuración
+const modal = document.getElementById('configModal');
+function openModal(){modal.style.display='block'; loadModels();}
+function closeModal(){modal.style.display='none';}
+
+function saveConfig(){
+    localStorage.setItem('apiKey', document.getElementById('apiKey').value);
+    localStorage.setItem('model', document.getElementById('modelSelect').value);
+    checkAssistant();
+    closeModal();
+}
+
+function loadModels(){
+    const key = localStorage.getItem('apiKey');
+    fetch('https://openrouter.ai/api/v1/models', {headers:{'Authorization': 'Bearer ' + key}})
+      .then(r=>r.json())
+      .then(data=>{
+        const select = document.getElementById('modelSelect');
+        select.innerHTML='';
+        data.data.filter(m=>!m.id.includes('paid')).forEach(m=>{
+            const opt=document.createElement('option');
+            opt.value=m.id; opt.textContent=m.id; select.appendChild(opt);});
+        select.value=localStorage.getItem('model')||'';
+        document.getElementById('apiKey').value=key||'';
+      });
+}
+
+function checkAssistant(){
+    const key=localStorage.getItem('apiKey');
+    const model=localStorage.getItem('model');
+    document.getElementById('voiceBtn').style.display = key&&model ? 'block':'none';
+}
+
+checkAssistant();
+
+// Placeholder para integración de voz (reconocimiento/síntesis del navegador)

--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Registro Ontime",
+  "short_name": "Ontime",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#f5faff",
+  "theme_color": "#003366",
+  "icons": []
+}

--- a/app/static/service-worker.js
+++ b/app/static/service-worker.js
@@ -1,0 +1,13 @@
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open('pwa-cache').then(cache => cache.addAll([
+    '/',
+    '/static/style.css',
+    '/static/app.js'
+  ])));
+});
+
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(response => response || fetch(e.request))
+  );
+});

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,10 @@
+body {font-family: Arial, sans-serif; padding: 20px; background: #f5faff;}
+h1 {color: #003366;}
+label {display:block; margin-top:10px;}
+input, textarea, select {width:100%; padding:6px;}
+button {margin-top:10px;}
+#configBtn {position:fixed; bottom:10px; right:10px;}
+.modal {display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.4);}
+.modal-content {background:white; padding:20px; margin:10% auto; width:80%; max-width:400px;}
+.close {float:right; cursor:pointer;}
+@media (min-width:600px){input, textarea, select {width:50%;}}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Registro de Jornada</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Registro de Jornada Diaria</h1>
+    <form action="/guardar" method="post" id="jornadaForm">
+        <label>Fecha:</label>
+        <input type="date" name="fecha" value="{{ last.fecha if last else '' }}" required>
+        <label>Hora inicio:</label>
+        <input type="time" name="hora_inicio" required>
+        <label>Matrícula:</label>
+        <input type="text" name="matricula" value="{{ last.matricula if last else '' }}" required>
+        <label>Kms iniciales:</label>
+        <input type="number" name="kms_inicio" value="{{ last.kms_fin if last else '' }}" required>
+        <label>Remolque:</label>
+        <input type="text" name="remolque">
+        <label>Hora fin:</label>
+        <input type="time" name="hora_fin" required>
+        <label>Kms finales:</label>
+        <input type="number" name="kms_fin" required>
+        <label>Observaciones:</label>
+        <textarea name="observaciones"></textarea>
+        <h3>Trayectos</h3>
+        <div id="trayectos"></div>
+        <button type="button" onclick="addTrayecto()">Añadir Trayecto</button>
+        <br>
+        <button type="submit">Guardar Jornada</button>
+    </form>
+    <a href="/jornadas">Consultar Jornadas Anteriores</a>
+    <button id="voiceBtn" style="display:none">Asistente por Voz</button>
+
+    <div id="configModal" class="modal">
+        <div class="modal-content">
+            <span class="close" onclick="closeModal()">&times;</span>
+            <h2>Configuración de OpenRouter</h2>
+            <label>API Key:</label>
+            <input type="text" id="apiKey"><br>
+            <a href="https://openrouter.ai" target="_blank">Obtener API gratuita</a><br>
+            <label>Modelo:</label>
+            <select id="modelSelect"></select>
+            <button onclick="saveConfig()">Guardar</button>
+        </div>
+    </div>
+    <button id="configBtn" onclick="openModal()">⚙️</button>
+    <script src="{{ url_for('static', filename='app.js') }}"></script>
+    <script>if ("serviceWorker" in navigator) {navigator.serviceWorker.register("{{ url_for('static', filename='service-worker.js') }}");}</script>
+</body>
+</html>

--- a/app/templates/jornadas.html
+++ b/app/templates/jornadas.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Jornadas Registradas</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Jornadas Anteriores</h1>
+    <table>
+        <tr><th>Fecha</th><th>Inicio</th><th>Fin</th><th>Matrícula</th><th>Kms</th><th>Acciones</th></tr>
+        {% for j in jornadas %}
+        <tr>
+            <td>{{ j.fecha }}</td>
+            <td>{{ j.hora_inicio }}</td>
+            <td>{{ j.hora_fin }}</td>
+            <td>{{ j.matricula }}</td>
+            <td>{{ j.kms_inicio }}-{{ j.kms_fin }}</td>
+            <td>
+                <form action="/jornadas/{{ j.id }}/eliminar" method="post" style="display:inline">
+                    <button type="submit">Borrar</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+    <a href="/">Volver</a>
+</body>
+</html>


### PR DESCRIPTION
## Resumen
- Añadida aplicación Flask con conexión MySQL y generación de PDF/CSV
- Plantillas HTML para registrar jornadas y consultarlas
- Archivos estáticos para PWA: CSS, JS, manifest y service worker
- Archivo con instrucciones del asistente de voz
- Documentación en README sobre la ejecución

## Testing
- `python3 -m py_compile app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6886630fcb24832c9673f2e880db4d27