### PR TITLE
Implementación PWA de registro de jornada

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,21 @@ Este proyecto es una aplicación web progresiva (PWA) diseñada para digitalizar
 - Base de datos: MySQL
 - Generación de documentos: wkhtmltopdf o equivalente
 
+## Puesta en marcha
+
+Instala las dependencias en un entorno Python y ejecuta `app.py`:
+
+```bash
+pip install flask flask-cors mysql-connector-python pdfkit
+python app.py
+```
+
+Para la generación de PDF es necesario tener instalado `wkhtmltopdf` en el sistema.
+
+El asistente por voz usa la API de OpenRouter configurada desde el botón de ajustes (⚙️). Si no se introduce una API válida, el botón de voz permanecerá oculto.
+
 ## Estado actual
 
-Repositorio iniciado el 27/07/2025. Preparado para recibir los archivos generados automáticamente por el Agente GPT.
+Aplicación mínima funcional con registro y consulta de jornadas, generación de PDFs y configuración básica del asistente por voz. Algunas funciones avanzadas pueden requerir ajustes adicionales.
 
 ---

--- a/app.py
+++ b/app.py
@@ -1,0 +1,80 @@
+import os
+from flask import Flask, render_template, request, jsonify, send_file
+from flask_cors import CORS
+import mysql.connector
+from io import BytesIO
+from datetime import datetime
+
+app = Flask(__name__)
+CORS(app)
+
+def get_db():
+    return mysql.connector.connect(
+        host='srv1789.hstgr.io',
+        user='u643065128_ontime',
+        password='Time1On2',
+        database='u643065128_ontime'
+    )
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/consultar')
+def consultar():
+    return render_template('consultar.html')
+
+@app.route('/api/jornadas', methods=['GET', 'POST'])
+def jornadas():
+    db = get_db()
+    cur = db.cursor(dictionary=True)
+    if request.method == 'POST':
+        datos = request.form
+        cur.execute("""
+            INSERT INTO jornadas (fecha, hora_inicio, hora_fin, matricula, remolque, kms_inicio, kms_fin, observaciones)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
+        """, (
+            datos['inicio'][:10], datos['inicio'][11:], datos['fin'][11:], datos['matricula'], datos.get('remolque'), datos['kms_inicio'], datos['kms_fin'], datos.get('observaciones')
+        ))
+        jornada_id = cur.lastrowid
+        trayectos = zip(datos.getlist('hora_salida[]'), datos.getlist('origen[]'), datos.getlist('hora_llegada[]'), datos.getlist('destino[]'))
+        for hs, o, hl, d in trayectos:
+            cur.execute("""
+                INSERT INTO trayectos (jornada_id, hora_salida, origen, hora_llegada, destino)
+                VALUES (%s,%s,%s,%s,%s)
+            """, (jornada_id, hs, o, hl, d))
+        db.commit()
+        db.close()
+        return '', 201
+    else:
+        desde = request.args.get('desde')
+        hasta = request.args.get('hasta')
+        sql = 'SELECT * FROM jornadas'
+        params = []
+        if desde and hasta:
+            sql += ' WHERE fecha BETWEEN %s AND %s'
+            params = [desde, hasta]
+        cur.execute(sql, params)
+        datos = cur.fetchall()
+        db.close()
+        return jsonify(datos)
+
+@app.route('/api/jornadas/<int:jid>/pdf')
+def jornada_pdf(jid):
+    db = get_db()
+    cur = db.cursor(dictionary=True)
+    cur.execute('SELECT * FROM jornadas WHERE id=%s', (jid,))
+    j = cur.fetchone()
+    cur.execute('SELECT * FROM trayectos WHERE jornada_id=%s', (jid,))
+    t = cur.fetchall()
+    db.close()
+    html = render_template('reporte.html', j=j, trayectos=t)
+    try:
+        import pdfkit
+        pdf = pdfkit.from_string(html, False)
+        return send_file(BytesIO(pdf), download_name='reporte.pdf', mimetype='application/pdf')
+    except Exception as e:
+        return html
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+    "name": "Registro de Jornada ONTIME",
+    "short_name": "Jornada",
+    "start_url": "/",
+    "display": "standalone",
+    "background_color": "#f2f6ff",
+    "theme_color": "#004080",
+    "icons": []
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+flask-cors
+mysql-connector-python
+pdfkit

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,9 @@
+body{font-family:Arial,Helvetica,sans-serif;margin:20px;background:#f2f6ff;color:#003366;}
+h1{color:#004080;}
+form,label{display:flex;flex-direction:column;margin-bottom:10px;}
+.trayecto{border:1px solid #ccc;padding:5px;margin-top:5px;}
+button{margin-top:5px;}
+button.config{position:fixed;bottom:10px;right:10px;}
+.modal{position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:center;}
+.modal-content{background:#fff;padding:20px;}
+@media(min-width:600px){form{max-width:500px;}}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,37 @@
+// Funciones de UI para añadir trayectos
+const trayectosDiv = document.getElementById('trayectos');
+document.getElementById('add-trayecto').addEventListener('click', () => {
+    const div = document.createElement('div');
+    div.className = 'trayecto';
+    div.innerHTML = `
+        <label>Salida: <input type="time" name="hora_salida[]" required></label>
+        <label>Origen: <input type="text" name="origen[]" required></label>
+        <label>Llegada: <input type="time" name="hora_llegada[]" required></label>
+        <label>Destino: <input type="text" name="destino[]" required></label>
+        <button type="button" class="del">Eliminar</button>
+    `;
+    div.querySelector('.del').addEventListener('click', () => div.remove());
+    trayectosDiv.appendChild(div);
+});
+
+// Envío de formulario
+const form = document.getElementById('jornada-form');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const datos = new FormData(form);
+    const res = await fetch('/api/jornadas', {
+        method: 'POST',
+        body: datos
+    });
+    if(res.ok) {
+        alert('Guardado');
+        form.reset();
+        trayectosDiv.innerHTML = '';
+    } else {
+        alert('Error al guardar');
+    }
+});
+
+if('serviceWorker' in navigator){
+    navigator.serviceWorker.register('/sw.js');
+}

--- a/static/js/consultar.js
+++ b/static/js/consultar.js
@@ -1,0 +1,23 @@
+async function cargar(desde='', hasta=''){
+    const params = new URLSearchParams();
+    if(desde) params.append('desde', desde);
+    if(hasta) params.append('hasta', hasta);
+    const res = await fetch('/api/jornadas?'+params.toString());
+    const data = await res.json();
+    const tbody = document.querySelector('#tabla-jornadas tbody');
+    tbody.innerHTML = '';
+    data.forEach(j => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${j.fecha}</td><td>${j.hora_inicio}</td><td>${j.hora_fin}</td><td>${j.matricula}</td><td><a href="/api/jornadas/${j.id}/pdf" target="_blank">PDF</a></td>`;
+        tbody.appendChild(tr);
+    });
+}
+
+document.getElementById('filtro').addEventListener('submit', e => {
+    e.preventDefault();
+    const desde = e.target.desde.value;
+    const hasta = e.target.hasta.value;
+    cargar(desde, hasta);
+});
+
+cargar();

--- a/static/js/voice.js
+++ b/static/js/voice.js
@@ -1,0 +1,96 @@
+// Configuración guardada en LocalStorage
+function getConfig(){
+    return JSON.parse(localStorage.getItem('vozConf')||'{}');
+}
+function setConfig(cfg){
+    localStorage.setItem('vozConf', JSON.stringify(cfg));
+}
+
+// Cargar modelos de openrouter (solo gratuitos)
+async function cargarModelos(select){
+    const cfg = getConfig();
+    if(!cfg.api) return;
+    try{
+        const res = await fetch('https://openrouter.ai/api/v1/models', {
+            headers:{'Authorization':'Bearer '+cfg.api}
+        });
+        const data = await res.json();
+        select.innerHTML = '';
+        data.data.filter(m=>m.id && m.id.includes('free')).forEach(m=>{
+            const opt=document.createElement('option');
+            opt.value=m.id; opt.textContent=m.id;
+            select.appendChild(opt);
+        });
+    }catch(e){console.error(e);}
+}
+
+// Modal de configuración
+function showConfig(){
+    const modal=document.createElement('div');
+    modal.className='modal';
+    modal.innerHTML=`
+        <div class="modal-content">
+            <label>API Key:<input type="text" id="apiKey"></label>
+            <p><a href="https://openrouter.ai" target="_blank">Obtener API gratuita</a></p>
+            <label>Modelo:<select id="modelo"></select></label>
+            <button id="guardar">Guardar</button>
+        </div>`;
+    document.body.appendChild(modal);
+    const cfg=getConfig();
+    document.getElementById('apiKey').value=cfg.api||'';
+    cargarModelos(document.getElementById('modelo')).then(()=>{
+        document.getElementById('modelo').value=cfg.modelo||'';
+    });
+    document.getElementById('guardar').onclick=()=>{
+        setConfig({api:document.getElementById('apiKey').value, modelo:document.getElementById('modelo').value});
+        modal.remove();
+    };
+}
+
+document.getElementById('btn-config').addEventListener('click', showConfig);
+
+function checkConfig(){
+    const cfg=getConfig();
+    if(cfg.api && cfg.modelo){
+        document.getElementById('btn-voice').style.display='block';
+    }
+}
+
+checkConfig();
+
+let recognizer, synthesis;
+if('webkitSpeechRecognition' in window){
+    recognizer = new webkitSpeechRecognition();
+    recognizer.lang='es-ES';
+}
+if('speechSynthesis' in window){
+    synthesis = window.speechSynthesis;
+}
+
+async function preguntar(text){
+    const cfg=getConfig();
+    if(!cfg.api||!cfg.modelo)return;
+    const res=await fetch('https://openrouter.ai/api/v1/chat/completions',{
+        method:'POST',
+        headers:{'Content-Type':'application/json','Authorization':'Bearer '+cfg.api},
+        body:JSON.stringify({model:cfg.modelo,messages:[{role:'system',content:'Eres un asistente para Antonio Becerra Ortega.'},{role:'user',content:text}]})
+    });
+    const data=await res.json();
+    const respuesta=data.choices[0].message.content;
+    if(synthesis){
+        const utter=new SpeechSynthesisUtterance(respuesta);
+        synthesis.speak(utter);
+    }
+}
+
+document.getElementById('btn-voice').onclick=()=>{
+    if(!recognizer){alert('Reconocimiento de voz no disponible');return;}
+    recognizer.start();
+};
+
+if(recognizer){
+    recognizer.onresult=(e)=>{
+        const text=e.results[0][0].transcript;
+        preguntar(text);
+    };
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,4 @@
+self.addEventListener('install', e=>{
+    self.skipWaiting();
+});
+self.addEventListener('fetch', ()=>{});

--- a/templates/consultar.html
+++ b/templates/consultar.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/css/style.css">
+    <title>Consultar Jornadas</title>
+</head>
+<body>
+    <h1>Jornadas Registradas</h1>
+    <form id="filtro">
+        <label>Desde: <input type="date" name="desde"></label>
+        <label>Hasta: <input type="date" name="hasta"></label>
+        <button type="submit">Buscar</button>
+    </form>
+    <table id="tabla-jornadas">
+        <thead>
+            <tr><th>Fecha</th><th>Inicio</th><th>Fin</th><th>Matrícula</th><th>Acciones</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <a href="/">Volver</a>
+    <script src="/static/js/consultar.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="manifest" href="/manifest.json">
+    <link rel="stylesheet" href="/static/css/style.css">
+    <title>Registro de Jornada</title>
+</head>
+<body>
+    <h1>Registro de Jornada Diaria</h1>
+    <button id="btn-voice" style="display:none">Hablar</button>
+    <button id="btn-config" class="config">⚙️</button>
+    <form id="jornada-form">
+        <label>Fecha y hora de inicio:
+            <input type="datetime-local" name="inicio" required>
+        </label>
+        <label>Matrícula:
+            <input type="text" name="matricula" required>
+        </label>
+        <label>Kms iniciales:
+            <input type="number" name="kms_inicio" required>
+        </label>
+        <label>Remolque:
+            <input type="text" name="remolque">
+        </label>
+        <label>Fecha y hora de fin:
+            <input type="datetime-local" name="fin" required>
+        </label>
+        <label>Kms finales:
+            <input type="number" name="kms_fin" required>
+        </label>
+        <label>Observaciones:
+            <textarea name="observaciones"></textarea>
+        </label>
+        <div id="trayectos">
+            <!-- Subformularios de trayectos -->
+        </div>
+        <button type="button" id="add-trayecto">Añadir Trayecto</button>
+        <button type="submit">Guardar Jornada</button>
+    </form>
+    <a href="/consultar">Consultar Jornadas Anteriores</a>
+
+    <script src="/static/js/app.js"></script>
+    <script src="/static/js/voice.js"></script>
+</body>
+</html>

--- a/templates/reporte.html
+++ b/templates/reporte.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body{font-family:Arial,Helvetica,sans-serif;}
+        table{width:100%;border-collapse:collapse;}
+        th,td{border:1px solid #000;padding:4px;text-align:left;}
+    </style>
+</head>
+<body>
+    <h1>Informe de Jornada</h1>
+    <p>Conductor: Antonio Becerra Ortega - ONTIME</p>
+    <p>Fecha: {{j.fecha}}</p>
+    <p>Inicio: {{j.hora_inicio}} - Fin: {{j.hora_fin}}</p>
+    <p>Matrícula: {{j.matricula}} Remolque: {{j.remolque}}</p>
+    <p>Kms: {{j.kms_inicio}} - {{j.kms_fin}}</p>
+    <h2>Trayectos</h2>
+    <table>
+        <tr><th>Salida</th><th>Origen</th><th>Llegada</th><th>Destino</th></tr>
+        {% for t in trayectos %}
+        <tr><td>{{t.hora_salida}}</td><td>{{t.origen}}</td><td>{{t.hora_llegada}}</td><td>{{t.destino}}</td></tr>
+        {% endfor %}
+    </table>
+    <p>Observaciones: {{j.observaciones}}</p>
+</body>
+</html>

--- a/voice_system.txt
+++ b/voice_system.txt
@@ -1,0 +1,1 @@
+Eres un asistente de voz para Antonio Becerra Ortega. Ayudas a registrar turnos de conducción y a consultar información previa. Responde siempre en español de España de forma amable y concisa.


### PR DESCRIPTION
## Summary
- crear backend Flask con conexión a MySQL y generación de PDF
- añadir páginas HTML para registrar y consultar jornadas
- incluir scripts JS para formulario dinámico y asistente de voz
- definir estilos y manifiesto para PWA
- documentar puesta en marcha en README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6886630fcb24832c9673f2e880db4d27